### PR TITLE
make new keyword optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Require `engine-light` and create an object
 var EngineLight = require('engine-light')
 
 var engineLight = new EngineLight()
+// can also be used without the `new` keyword:
+engineLight = EngineLight()
 ```
 
 Then use it right away to generate Engine Light compliant responses

--- a/index.js
+++ b/index.js
@@ -1,6 +1,9 @@
 var resolved = require('resolved')
 
 function EngineLight() {
+  if (!(this instanceof EngineLight)) {
+    return new EngineLight()
+  }
   this._dependencies = []
   this._resources = {}
 }

--- a/test/engine-light.js
+++ b/test/engine-light.js
@@ -14,6 +14,11 @@ describe('Engine Light', function() {
     el.should.be.instanceof(Object)
   })
 
+  it('should create a new EngineLight object even without the new keywodrd', function () {
+    var el = EngineLight()
+    el.should.be.instanceof(EngineLight)
+  })
+
   it('should add depencies with addDependency(string)', function() {
     var el = new EngineLight()
 
@@ -59,7 +64,6 @@ describe('Engine Light', function() {
     var el = new EngineLight()
 
     el.addResource('Sengrid')
-    console.log(typeof(el._resources['Sengrid']))
     el._resources['Sengrid'].should.be.an.instanceof(Function)
   })
 


### PR DESCRIPTION
This is a style of constructor that I use frequently. It eliminates boilerplate for downstream consumers. Basically, rather than writing:

``` js
var EngineLight = require('engine-light')

var engineLight = new EngineLight()
app.use(engineLight.getMiddleware())
```

you could instead write something like

``` js
var engineLight = require('engine-light')

app.use(engineLight().getMiddleware())
```

which just saves steps. also, it makes code look a little less java-y.
