### PR TITLE
use SSE time per @migurski

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,10 +38,16 @@ function executeResourceFunctions(resources) {
 EngineLight.prototype.buildResponseObject = function (status) {
   return resolved({
     'status': status,
-    'updated': new Date().getTime(),
+    'updated': getUnixTimestamp(),
     'dependencies': this._dependencies,
     'resources': executeResourceFunctions(this._resources)
   })
+}
+
+// () => Number
+// returns Seconds Since Epoch, rather than JS millisecond timestamp
+function getUnixTimestamp() {
+  return Math.floor(new Date().getTime() / 1000)
 }
 
 // (String?) => Promise<String>

--- a/test/engine-light.js
+++ b/test/engine-light.js
@@ -78,6 +78,16 @@ describe('Engine Light', function() {
 
   })
 
+  it('should return time in Seconds Since Epoch', function (done) {
+    var el = new EngineLight()
+
+    el.getStatus().then(function (str) {
+      var time = String(JSON.parse(str).updated)
+      time.length.should.equal(10)
+    })
+    .then(done, done)
+  })
+
   it('should return status set to any value', function(done) {
     var el = new EngineLight(),
         expected = JSON.stringify('yo')


### PR DESCRIPTION
from slack:

```
jden: @erica: engine light is yelling at me when i try to update the monitoring url for our app!
[16:07] jden: "is unavailable or does not return a valid response"
[16:07] jden: when in fact http://dev.bestnestapp.com/.well-known/status
[16:14] migurski: try a unix timestamp? the one there is in msec, which is incorrect
[16:15] migurski: they’re normally in seconds
[16:15] migurski: (my first guess)
```
